### PR TITLE
Allow passing extra kwargs into register decorator

### DIFF
--- a/flask_mongorest/__init__.py
+++ b/flask_mongorest/__init__.py
@@ -19,10 +19,10 @@ class MongoRest(object):
             pk_type = kwargs.pop('pk_type', 'string')
             view_func = klass.as_view(name)
             if List in klass.methods: 
-                self.app.add_url_rule(url, defaults={'pk': None}, view_func=view_func, methods=[List.method])
+                self.app.add_url_rule(url, defaults={'pk': None}, view_func=view_func, methods=[List.method], **kwargs)
             if Create in klass.methods or BulkUpdate in klass.methods:
-                self.app.add_url_rule(url, view_func=view_func, methods=[x.method for x in klass.methods if x in (Create, BulkUpdate)])
-            self.app.add_url_rule('%s<%s:%s>/' % (url, pk_type, 'pk'), view_func=view_func, methods=[x.method for x in klass.methods])
+                self.app.add_url_rule(url, view_func=view_func, methods=[x.method for x in klass.methods if x in (Create, BulkUpdate)], **kwargs)
+            self.app.add_url_rule('%s<%s:%s>/' % (url, pk_type, 'pk'), view_func=view_func, methods=[x.method for x in klass.methods], **kwargs)
             return klass
         return decorator
 


### PR DESCRIPTION
In order to support extra key-word arguments in add_url_rule method, e.g. subdomain.
