### PR TITLE
Case-insensitive operators

### DIFF
--- a/flask_mongorest/operators.py
+++ b/flask_mongorest/operators.py
@@ -28,6 +28,9 @@ class Gte(Operator):
 
 class Exact(Operator):
     op = 'exact'
+    
+class IExact(Operator):
+    op = 'iexact'
 
 class In(Operator):
     op = 'in'
@@ -48,12 +51,21 @@ class In(Operator):
 
 class Contains(Operator):
     op = 'contains'
+    
+class IContains(Operator):
+    op = 'icontains'
 
 class Startswith(Operator):
     op = 'startswith'
+    
+class IStartswith(Operator):
+    op = 'istartswith'
 
 class Endswith(Operator):
     op = 'endswith'
+    
+class IEndswith(Operator):
+    op = 'iendswith'
 
 class Boolean(Operator):
     op = 'exact'


### PR DESCRIPTION
Found you guys lacked case-insensitive operators MongoEngine has - added them.
