### PR TITLE
Fix test failing to serialize DBRef entries

### DIFF
--- a/flask_mongorest/resources.py
+++ b/flask_mongorest/resources.py
@@ -147,7 +147,7 @@ class Resource(object):
 
             if isinstance(field_instance, (ReferenceField, EmbeddedDocumentField)):
                 if field_name in self._related_resources:
-                    return field_value and not isinstance(field_value, DBRef) and self._related_resources[field_name]().serialize_field(field_value, **kwargs)
+                    return field_value and self._related_resources[field_name]().serialize_field(field_value, **kwargs)
                 else:
                     if isinstance(field_value, DBRef):
                         return field_value


### PR DESCRIPTION
I'm not certain if this change would have unexpected side effects, but the tests now pass.
