### PR TITLE
Don't return parent's child_document_resources in subclasses.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,4 +4,4 @@ dependencies:
 
 test:
     pre:
-        - flake8 ./
+        - flake8 --ignore=E2,E302,W391,F403,F405,E501,E731,F999 --exclude=.eggs,docs ./

--- a/flask_mongorest/resources.py
+++ b/flask_mongorest/resources.py
@@ -180,7 +180,13 @@ class Resource(object):
         return self.rename_fields
 
     def get_child_document_resources(self):
-        return self.child_document_resources
+        # By default, don't inherit child_document_resources. This lets us have
+        # multiple resources for a child document without having to reset the
+        # child_document_resources property in the subclass.
+        if 'child_document_resources' in self.__class__.__dict__:
+            return self.child_document_resources
+        else:
+            return {}
 
     def get_filters(self):
         filters = {}

--- a/flask_mongorest/resources.py
+++ b/flask_mongorest/resources.py
@@ -56,6 +56,7 @@ class Resource(object):
             'Cannot rename multiple fields to the same name'
         self._filters = self.get_filters()
         self._child_document_resources = self.get_child_document_resources()
+        self._default_child_resource_document = self.get_default_child_resource_document()
         self.data = None
         self._dirty_fields = None
 
@@ -188,6 +189,13 @@ class Resource(object):
         else:
             return {}
 
+    def get_default_child_resource_document(self):
+        # See comment on get_child_document_resources.
+        if 'default_child_resource_document' in self.__class__.__dict__:
+            return self.default_child_resource_document
+        else:
+            return None
+
     def get_filters(self):
         filters = {}
         for field, operators in getattr(self, 'filters', {}).iteritems():
@@ -208,8 +216,8 @@ class Resource(object):
     def _subresource(self, obj):
         """Selects and creates an appropriate sub-resource class for delegation or return None if there isn't one"""
         s_class = self._child_document_resources.get(obj.__class__)
-        if not s_class and self.default_child_resource_document:
-            s_class = self._child_document_resources[self.default_child_resource_document]
+        if not s_class and self._default_child_resource_document:
+            s_class = self._child_document_resources[self._default_child_resource_document]
         if s_class and s_class != self.__class__:
             r = s_class()
             r.data = self.data

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 # Stops exit traceback on tests
 # TODO this makes flake8's F401 fail - maybe there's a better way
 try:
-    import multiprocessing
+    import multiprocessing # noqa
 except:
     pass
 


### PR DESCRIPTION
By default, don't inherit `child_document_resources`. This lets us have multiple resources for a child document without having to reset the `child_document_resources` property in the subclass.

Consider the following example:

```
class ParentResource(Resource):
    child_document_resources = { Child: 'ChildResource' }

class ChildResource(ParentResource):
    document = Child
    fields = ['id']

class VerboseChildResource(ChildResource):
    fields = ['id', 'foo', 'bar']
```

If we call `VerboseChildResource().serialize(obj)`, before this PR it would delegate the call to `ChildResource` since `VerboseChildResource` would inherit `child_document_resources` from `ParentResource`. This is usually not expected behavior, so I'm changing `get_child_document_resources` to only return the current class' `child_document_resources`. In the rare case where this isn't desirable, a parent can always explicitly change the behavior by overriding `get_child_document_resources`.