### PR TITLE
Support for Python 3 / latest MongoEngine

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ from flask_mongorest import MongoRest
 from flask_mongorest.views import ResourceView
 from flask_mongorest.resources import Resource
 from flask_mongorest import operators as ops
-from flask_mongorest import methods  
+from flask_mongorest import methods
 
 
 app = Flask(__name__)

--- a/circle.yml
+++ b/circle.yml
@@ -6,4 +6,5 @@ test:
     pre:
         - flake8 ./
     override:
+        - pyenv global 2.7.11 3.5.1
         - tox

--- a/example/app.py
+++ b/example/app.py
@@ -23,7 +23,7 @@ app.config.update(
         'HOST': 'localhost',
         'PORT': 27017,
         'DB': 'mongorest_example_app',
-        'TZ_AWARE': True,
+        'TZ_AWARE': False,
     },
 )
 

--- a/example/documents.py
+++ b/example/documents.py
@@ -29,7 +29,10 @@ class Post(Document):
     author = ReferenceField(User)
     editor = ReferenceField(User)
     tags = ListField(StringField(max_length=30))
-    user_lists = ListField(SafeReferenceField(User))
+    try:
+        user_lists = ListField(SafeReferenceField(User))
+    except NameError:
+        user_lists = ListField(ReferenceField(User))
     sections = ListField(EmbeddedDocumentField(Content))
     content = EmbeddedDocumentField(Content)
     is_published = BooleanField()

--- a/flask_mongorest/__init__.py
+++ b/flask_mongorest/__init__.py
@@ -10,10 +10,10 @@ class MongoRest(object):
 
     def register(self, **kwargs):
         def decorator(klass):
-
-            # Construct a url based on a 'name' kwarg with a fallback to a Mongo document's name
+            # Construct a url based on a 'name' kwarg with a fallback to the
+            # view's class name. Note that the name must be unique.
             document_name = klass.resource.document.__name__.lower()
-            name = kwargs.pop('name', document_name)
+            name = kwargs.pop('name', klass.__name__)
             url = kwargs.pop('url', '/%s/' % document_name)
 
             # Insert the url prefix, if it exists

--- a/flask_mongorest/__init__.py
+++ b/flask_mongorest/__init__.py
@@ -12,9 +12,11 @@ class MongoRest(object):
         def decorator(klass):
             # Construct a url based on a 'name' kwarg with a fallback to the
             # view's class name. Note that the name must be unique.
-            document_name = klass.resource.document.__name__.lower()
             name = kwargs.pop('name', klass.__name__)
-            url = kwargs.pop('url', '/%s/' % document_name)
+            url = kwargs.pop('url', None)
+            if not url:
+                document_name = klass.resource.document.__name__.lower()
+                url = '/%s/' % document_name
 
             # Insert the url prefix, if it exists
             if self.url_prefix:

--- a/flask_mongorest/resources.py
+++ b/flask_mongorest/resources.py
@@ -1,6 +1,5 @@
 import json
 import mongoengine
-import sys
 
 from bson.dbref import DBRef
 from bson.objectid import ObjectId

--- a/flask_mongorest/utils.py
+++ b/flask_mongorest/utils.py
@@ -17,7 +17,7 @@ def isint(int_str):
 class MongoEncoder(json.JSONEncoder):
     def default(self, value, **kwargs):
         if isinstance(value, ObjectId):
-            return unicode(value)
+            return str(value)
         if isinstance(value, DBRef):
             return value.id
         if isinstance(value, datetime.datetime):
@@ -27,6 +27,11 @@ class MongoEncoder(json.JSONEncoder):
         if isinstance(value, decimal.Decimal):
             return str(value)
         return super(MongoEncoder, self).default(value, **kwargs)
+
+try:
+    cmp
+except NameError: # Python 3
+    cmp = lambda a, b: (a>b)-(a<b)
 
 def cmp_fields(ordering):
     # Takes a list of fields and directions and returns a
@@ -55,7 +60,7 @@ def equal(a, b):
     if isinstance(a, dict) and isinstance(b, dict):
         if sorted(a.keys()) != sorted(b.keys()):
             return False
-        for k, v in a.iteritems():
+        for k, v in a.items():
             if not equal(b[k], v):
                 return False
         return True
@@ -73,7 +78,7 @@ def equal(a, b):
         # Don't evaluate lazy documents
         if getattr(a, '_lazy', False) and getattr(b, '_lazy', False):
             return True
-        return equal(a.to_dict(), b.to_dict())
+        return equal(dict(a.to_mongo()), dict(b.to_mongo()))
 
     # Since comparing an aware and unaware datetime results in an
     # exception and we may assign unaware datetimes to objects that

--- a/flask_mongorest/views.py
+++ b/flask_mongorest/views.py
@@ -17,10 +17,10 @@ render_html = lambda **payload: render_template('mongorest/debug.html', data=jso
 
 def serialize_mongoengine_validation_error(e):
     def serialize_errors(errors):
-        if hasattr(errors, 'iteritems'):
-            return dict((k, serialize_errors(v)) for (k, v) in errors.iteritems())
+        if hasattr(errors, 'items'):
+            return dict((k, serialize_errors(v)) for (k, v) in errors.items())
         else:
-            return unicode(errors)
+            return str(errors)
 
     if e.errors:
         return {'field-errors': serialize_errors(e.errors)}
@@ -61,7 +61,7 @@ class ResourceView(View):
         except Unauthorized as e:
             return {'error': 'Unauthorized'}, '401 Unauthorized'
         except NotFound as e:
-            return {'error': unicode(e)}, '404 Not Found'
+            return {'error': str(e)}, '404 Not Found'
 
     def handle_validation_error(self, e):
         if isinstance(e, ValidationError):
@@ -138,7 +138,7 @@ class ResourceView(View):
         self._resource.validate_request()
         try:
             obj = self._resource.create_object()
-        except Exception, e:
+        except Exception as e:
             self.handle_validation_error(e)
 
         # Check if we have permission to create this object
@@ -161,7 +161,7 @@ class ResourceView(View):
 
         try:
             obj = self._resource.update_object(obj)
-        except Exception, e:
+        except Exception as e:
             self.handle_validation_error(e)
 
     def process_objects(self, objs):
@@ -174,7 +174,7 @@ class ResourceView(View):
             for obj in objs:
                 self.process_object(obj)
                 count += 1
-        except ValidationError, e:
+        except ValidationError as e:
             e.message['count'] = count
             raise e
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,7 @@ mimerender
 python-dateutil
 sphinx
 cleancat>=0.3
-Flask==0.9
+Flask>=0.9
 Flask-Views
-Flask-WTF==0.8.4
 pymongo<3.0
 flake8

--- a/requirements3.txt
+++ b/requirements3.txt
@@ -1,0 +1,10 @@
+-e git://github.com/closeio/cleancat.git#egg=cleancat-dev
+mongoengine
+flask-mongoengine
+mimerender
+python-dateutil
+sphinx
+Flask>=0.9
+Flask-Views
+pymongo
+flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,6 @@
 [nosetests]
 verbosity=2
 detailed-errors=True
-with-coverage=True
 cover-package=flask_mongorest
 cover-erase=True
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
         'Flask-MongoEngine',
         'mimerender',
         'nose',
-        'coverage',
         'python-dateutil',
         'cleancat'
     ],

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,6 +5,29 @@ import unittest
 import example.app as example
 from mongoengine.context_managers import query_counter
 
+try:
+    from mongoengine import SafeReferenceField
+except ImportError:
+    SafeReferenceField = None
+
+
+# HACK:
+# Because mongoengine doesn't allow you to customize the connection alias, and
+# because flask_mongoengine uses a different DEFAULT_CONNECTION_NAME from
+# mongoengine, we need to override this method to use flask_mongoengine's
+# get_db() method instead of mongoengine's get_db() method.
+try:
+    from flask_mongoengine import get_db
+
+    class query_counter(query_counter):
+        def __init__(self):
+            self.counter = 0
+            self.db = get_db()
+except ImportError:
+    # Older versions of flask-mongoengine don't have this issue.
+    pass
+
+
 def response_success(response, code=None):
     if code is None:
         assert 200 <= response.status_code < 300, 'Received %d response: %s' % (response.status_code, response.data)
@@ -18,9 +41,12 @@ def response_error(response, code=None):
         assert code == response.status_code, 'Received %d response: %s' % (response.status_code, response.data)
 
 def compare_req_resp(req_obj, resp_obj):
-    for k,v in req_obj.iteritems():
+    for k,v in req_obj.items():
         assert k in resp_obj.keys(), 'Key %r not in response (keys are %r)' % (k, resp_obj.keys())
         assert resp_obj[k] == v, 'Value for key %r should be %r but is %r' % (k, v, resp_obj[k])
+
+def resp_json(resp):
+    return json.loads(resp.get_data(as_text=True))
 
 
 class MongoRestTestCase(unittest.TestCase):
@@ -30,14 +56,14 @@ class MongoRestTestCase(unittest.TestCase):
             'email': '1@b.com',
             'first_name': 'alan',
             'last_name': 'baker',
-            'datetime': '2012-10-09T10:00:00+00:00',
+            'datetime': '2012-10-09T10:00:00',
         }
 
         self.user_2 = {
             'email': '2@b.com',
             'first_name': 'olivia',
             'last_name': 'baker',
-            'datetime': '2012-11-09T11:00:00+00:00',
+            'datetime': '2012-11-09T11:00:00',
         }
 
         self.post_1 = {
@@ -79,13 +105,13 @@ class MongoRestTestCase(unittest.TestCase):
         # create user 1
         resp = self.app.post('/user/', data=json.dumps(self.user_1))
         response_success(resp)
-        self.user_1_obj = json.loads(resp.data)
+        self.user_1_obj = resp_json(resp)
         compare_req_resp(self.user_1, self.user_1_obj)
 
         # create user 2
         resp = self.app.post('/user/', data=json.dumps(self.user_2))
         response_success(resp)
-        self.user_2_obj = json.loads(resp.data)
+        self.user_2_obj = resp_json(resp)
         compare_req_resp(self.user_2, self.user_2_obj)
 
     def tearDown(self):
@@ -110,13 +136,14 @@ class MongoRestTestCase(unittest.TestCase):
         # check for request params in response, except for date (since the format will differ)
         data_to_check = copy.copy(self.user_1_obj)
         del data_to_check['datetime']
-        compare_req_resp(data_to_check, json.loads(resp.data))
-        resp = json.loads(resp.data)
+        data = resp_json(resp)
+        compare_req_resp(data_to_check, data)
 
         # response from PUT should be completely identical as a subsequent GET
         # (including precision of datetimes)
-        resp2 = json.loads(self.app.get('/user/%s/' % self.user_1_obj['id']).data)
-        self.assertEqual(resp, resp2)
+        resp = self.app.get('/user/%s/' % self.user_1_obj['id'])
+        data2 = resp_json(resp)
+        self.assertEqual(data, data2)
 
     def test_model_validation(self):
         resp = self.app.post('/user/', data=json.dumps({
@@ -127,9 +154,9 @@ class MongoRestTestCase(unittest.TestCase):
             'datetime_local':'2012-08-13T05:25:04.362-03:30'
         }))
         response_error(resp)
-        errors = json.loads(resp.data)
+        errors = resp_json(resp)
         self.assertTrue('field-errors' in errors)
-        self.assertEqual(errors['field-errors'].keys(), ['email'])
+        self.assertEqual(set(errors['field-errors']), set(['email']))
 
         resp = self.app.put('/user/%s/' % self.user_1_obj['id'], data=json.dumps({
             'email': 'invalid',
@@ -137,19 +164,19 @@ class MongoRestTestCase(unittest.TestCase):
             'last_name': 'baker',
         }))
         response_error(resp)
-        errors = json.loads(resp.data)
+        errors = resp_json(resp)
         self.assertTrue('field-errors' in errors)
-        self.assertEqual(errors['field-errors'].keys(), ['email'])
+        self.assertEqual(set(errors['field-errors']), set(['email']))
 
         resp = self.app.put('/user/%s/' % self.user_1_obj['id'], data=json.dumps({
             'emails': ['one@example.com', 'invalid', 'second@example.com', 'invalid2'],
         }))
 
         response_error(resp)
-        errors = json.loads(resp.data)
+        errors = resp_json(resp)
         self.assertTrue('field-errors' in errors)
-        self.assertEqual(errors['field-errors'].keys(), ['emails'])
-        self.assertEqual(set(errors['field-errors']['emails']['errors'].keys()), set(['1', '3']))
+        self.assertEqual(set(errors['field-errors']), set(['emails']))
+        self.assertEqual(set(errors['field-errors']['emails']['errors']), set(['1', '3']))
 
     def test_resource_fields(self):
         resp = self.app.post('/testfields/', data=json.dumps({
@@ -158,15 +185,15 @@ class MongoRestTestCase(unittest.TestCase):
             'upper_name': 'INVALID',
         }))
         response_success(resp)
-        obj = json.loads(resp.data)
+        obj = resp_json(resp)
 
-        self.assertEqual(set(obj.keys()), set(['id', 'name', 'upper_name']))
+        self.assertEqual(set(obj), set(['id', 'name', 'upper_name']))
         self.assertEqual(obj['name'], 'thename')
         self.assertEqual(obj['upper_name'], 'THENAME')
 
         resp = self.app.get('/test/%s/' % obj['id'])
         response_success(resp)
-        obj = json.loads(resp.data)
+        obj = resp_json(resp)
 
         self.assertEqual(obj['name'], 'thename')
         # We can edit all the fields since we don't have a schema
@@ -176,7 +203,7 @@ class MongoRestTestCase(unittest.TestCase):
             'other': 'new othervalue',
         }))
         response_success(resp)
-        obj = json.loads(resp.data)
+        obj = resp_json(resp)
         self.assertEqual(obj['name'], 'thename')
         self.assertEqual(obj['other'], 'new othervalue')
 
@@ -185,7 +212,7 @@ class MongoRestTestCase(unittest.TestCase):
             'upper_name': 'INVALID',
         }))
         response_success(resp)
-        obj = json.loads(resp.data)
+        obj = resp_json(resp)
         self.assertEqual(obj['name'], 'namevalue2')
         self.assertEqual(obj['upper_name'], 'NAMEVALUE2')
 
@@ -195,7 +222,7 @@ class MongoRestTestCase(unittest.TestCase):
         self.post_1['user_lists'] = [self.user_1_obj['id'], self.user_2_obj['id']]
 
         resp = self.app.get('/user/')
-        objs = json.loads(resp.data)['data']
+        objs = resp_json(resp)['data']
         self.assertEqual(len(objs), 2)
 
         post = self.post_1.copy()
@@ -213,11 +240,11 @@ class MongoRestTestCase(unittest.TestCase):
         response_success(resp, code=200)
 
         # Get data about the Post we just POSTed
-        data = json.loads(resp.data)
+        data = resp_json(resp)
 
         # Look at current number of posts through an unrestricted view
         resp = self.app.get('/posts/')
-        tmp = json.loads(resp.data)
+        tmp = resp_json(resp)
         nposts = len(tmp["data"])
         # Should see 2
         self.assertEqual(2, nposts)
@@ -227,7 +254,7 @@ class MongoRestTestCase(unittest.TestCase):
 
         # Now look at posts through a restricted view
         resp = self.app.get('/restricted/')
-        tmp = json.loads(resp.data)
+        tmp = resp_json(resp)
         npubposts = len(tmp["data"])
         # Should only see 1 (published)
         self.assertEqual(1, npubposts)
@@ -269,7 +296,7 @@ class MongoRestTestCase(unittest.TestCase):
         # Should work
         response_success(resp, code=200)
 
-        data = json.loads(resp.data)
+        data = resp_json(resp)
 
         # Now let's try and delete an unpublished post
         resp = self.app.delete('/restricted/%s/' % (data["id"],),
@@ -279,7 +306,7 @@ class MongoRestTestCase(unittest.TestCase):
 
     def test_get(self):
         resp = self.app.get('/user/')
-        objs = json.loads(resp.data)['data']
+        objs = resp_json(resp)['data']
         self.assertEqual(len(objs), 2)
 
     def test_get_primary_user(self):
@@ -288,7 +315,7 @@ class MongoRestTestCase(unittest.TestCase):
         self.post_1['user_lists'] = [self.user_1_obj['id'], self.user_2_obj['id']]
         resp = self.app.post('/posts/', data=json.dumps(self.post_1))
         resp = self.app.get('/posts/?_include_primary_user=1')
-        objs = json.loads(resp.data)['data']
+        objs = resp_json(resp)['data']
         self.assertEqual(len(objs), 1)
         self.assertEqual(objs[0]['title'], 'first post!')
         self.assertTrue(len(objs[0]['primary_user']) > 0)
@@ -296,7 +323,7 @@ class MongoRestTestCase(unittest.TestCase):
     def test_get_empty_primary_user(self):
         resp = self.app.post('/posts/', data=json.dumps(self.post_2))
         resp = self.app.get('/posts/?_include_primary_user=1')
-        objs = json.loads(resp.data)['data']
+        objs = resp_json(resp)['data']
         self.assertEqual(len(objs), 1)
         self.assertEqual(objs[0]['title'], 'Second post')
         self.assertEqual(objs[0]['primary_user'], None)
@@ -307,57 +334,57 @@ class MongoRestTestCase(unittest.TestCase):
         self.post_1['user_lists'] = [self.user_1_obj['id'], self.user_2_obj['id']]
         resp = self.app.post('/posts/', data=json.dumps(self.post_1))
         response_success(resp)
-        compare_req_resp(self.post_1, json.loads(resp.data))
-        self.post_1_obj = json.loads(resp.data)
+        compare_req_resp(self.post_1, resp_json(resp))
+        self.post_1_obj = resp_json(resp)
         resp = self.app.get('/posts/%s/' % self.post_1_obj['id'])
         response_success(resp)
-        compare_req_resp(self.post_1_obj, json.loads(resp.data))
+        compare_req_resp(self.post_1_obj, resp_json(resp))
 
         self.post_1_obj['author_id'] = self.user_2_obj['id']
         resp = self.app.put('/posts/%s/' % self.post_1_obj['id'], data=json.dumps(self.post_1_obj))
         response_success(resp)
-        jd = json.loads(resp.data)
+        jd = resp_json(resp)
         self.assertEqual(self.post_1_obj['author_id'], jd["author_id"])
 
         response_success(resp)
-        compare_req_resp(self.post_1_obj, json.loads(resp.data))
-        self.post_1_obj = json.loads(resp.data)
+        compare_req_resp(self.post_1_obj, resp_json(resp))
+        self.post_1_obj = resp_json(resp)
 
         resp = self.app.post('/posts/', data=json.dumps(self.post_2))
         response_success(resp)
-        compare_req_resp(self.post_2, json.loads(resp.data))
-        self.post_2_obj = json.loads(resp.data)
+        compare_req_resp(self.post_2, resp_json(resp))
+        self.post_2_obj = resp_json(resp)
 
         #test filtering
 
         resp = self.app.get('/posts/?title__startswith=first')
         response_success(resp)
-        data_list = json.loads(resp.data)['data']
+        data_list = resp_json(resp)['data']
         compare_req_resp(self.post_1_obj, data_list[0])
 
         resp = self.app.get('/posts/?title__startswith=second')
         response_success(resp)
-        data_list = json.loads(resp.data)['data']
+        data_list = resp_json(resp)['data']
         self.assertEqual(data_list, [])
 
         resp = self.app.get('/posts/?title__in=%s,%s' % (self.post_1_obj['title'], self.post_2_obj['title']))
         response_success(resp)
-        posts = json.loads(resp.data)
+        posts = resp_json(resp)
         self.assertEqual(len(posts['data']), 2)
 
         resp = self.app.get('/user/?datetime=%s' % '2012-10-09 10:00:00')
         response_success(resp)
-        users = json.loads(resp.data)
+        users = resp_json(resp)
         self.assertEqual(len(users['data']), 1)
 
         resp = self.app.get('/user/?datetime__gt=%s' % '2012-10-08 10:00:00')
         response_success(resp)
-        users = json.loads(resp.data)
+        users = resp_json(resp)
         self.assertEqual(len(users['data']), 2)
 
         resp = self.app.get('/user/?datetime__gte=%s' % '2012-10-09 10:00:00')
         response_success(resp)
-        users = json.loads(resp.data)
+        users = resp_json(resp)
         self.assertEqual(len(users['data']), 2)
 
         # test negation
@@ -365,37 +392,37 @@ class MongoRestTestCase(unittest.TestCase):
         # exclude many
         resp = self.app.get('/posts/?title__not__in=%s,%s' % (self.post_1_obj['title'], self.post_2_obj['title']))
         response_success(resp)
-        posts = json.loads(resp.data)
+        posts = resp_json(resp)
         self.assertEqual(len(posts['data']), 0)
 
         # exclude one
         resp = self.app.get('/posts/?title__not__in=%s' % (self.post_1_obj['title']))
         response_success(resp)
-        posts = json.loads(resp.data)
+        posts = resp_json(resp)
         self.assertEqual(len(posts['data']), 1)
 
         resp = self.app.get('/posts/?author_id=%s' % self.user_2_obj['id'])
         response_success(resp)
-        data_list = json.loads(resp.data)['data']
+        data_list = resp_json(resp)['data']
         compare_req_resp(self.post_1_obj, data_list[0])
 
         resp = self.app.get('/posts/?is_published=true')
         response_success(resp)
-        data_list = json.loads(resp.data)['data']
+        data_list = resp_json(resp)['data']
         self.assertEqual(len(data_list), 1)
         compare_req_resp(self.post_1_obj, data_list[0])
 
         resp = self.app.get('/posts/?is_published=false')
         response_success(resp)
-        data_list = json.loads(resp.data)['data']
+        data_list = resp_json(resp)['data']
         self.assertEqual(len(data_list), 1)
         compare_req_resp(self.post_2_obj, data_list[0])
 
         # default exact filtering
         resp = self.app.get('/posts/?title__exact=first post!')
-        data_list_1 = json.loads(resp.data)['data']
+        data_list_1 = resp_json(resp)['data']
         resp = self.app.get('/posts/?title=first post!')
-        data_list_2 = json.loads(resp.data)['data']
+        data_list_2 = resp_json(resp)['data']
         self.assertEqual(data_list_1, data_list_2)
 
         # test bulk update
@@ -403,19 +430,19 @@ class MongoRestTestCase(unittest.TestCase):
             'description': 'Some description'
         }))
         response_success(resp)
-        data = json.loads(resp.data)
+        data = resp_json(resp)
         self.assertEqual(data['count'], 1)
 
         resp = self.app.put('/posts/', data=json.dumps({
             'description': 'Other description'
         }))
         response_success(resp)
-        data = json.loads(resp.data)
+        data = resp_json(resp)
         self.assertEqual(data['count'], 2)
 
         resp = self.app.get('/posts/')
         response_success(resp)
-        data_list = json.loads(resp.data)['data']
+        data_list = resp_json(resp)['data']
         self.assertEqual(data_list[0]['description'], 'Other description')
         self.assertEqual(data_list[1]['description'], 'Other description')
 
@@ -423,9 +450,9 @@ class MongoRestTestCase(unittest.TestCase):
             'description': 'X'*121 # too long
         }))
         response_error(resp)
-        data = json.loads(resp.data)
+        data = resp_json(resp)
         self.assertEqual(data['count'], 0)
-        self.assertEqual(data['field-errors'].keys(), ['description'])
+        self.assertEqual(set(data['field-errors']), set(['description']))
 
     def test_post_auto_art_tag(self):
         # create a post by vangogh and an 'art' tag should be added automatically
@@ -437,32 +464,33 @@ class MongoRestTestCase(unittest.TestCase):
             'last_name': 'Vangogh',
         }))
         response_success(resp)
-        author = json.loads(resp.data)['id']
+        author = resp_json(resp)['id']
 
         # create a post
         resp = self.app.post('/posts/', data=json.dumps(self.post_1))
         response_success(resp)
-        post = json.loads(resp.data)
+        post = resp_json(resp)
 
         resp = self.app.put('/posts/%s/' % post['id'], data=json.dumps({
             'author_id': author
         }))
         response_success(resp)
-        post = json.loads(resp.data)
+        post = resp_json(resp)
         post_obj = example.documents.Post.objects.get(pk=post['id'])
         self.assertTrue('art' in post_obj.tags)
         self.assertTrue('art' in post['tags'])
 
+    @unittest.skipIf(not SafeReferenceField, "SafeReferenceField not available")
     def test_broken_reference(self):
         # create a new user
         resp = self.app.post('/user/', data=json.dumps({
             'email': '3@b.com',
             'first_name': 'steve',
             'last_name': 'wiseman',
-            'datetime': '2012-11-09T11:00:00+00:00',
+            'datetime': '2012-11-09T11:00:00',
         }))
         response_success(resp)
-        user_3 = json.loads(resp.data)
+        user_3 = resp_json(resp)
 
         post = self.post_1.copy()
         post['author_id'] = self.user_1_obj['id']
@@ -470,9 +498,9 @@ class MongoRestTestCase(unittest.TestCase):
         post['user_lists'] = [user_3['id']]
         resp = self.app.post('/posts/', data=json.dumps(post))
         response_success(resp)
-        compare_req_resp(post, json.loads(resp.data))
+        compare_req_resp(post, resp_json(resp))
 
-        post = json.loads(resp.data)
+        post = resp_json(resp)
 
         # remove the user and see if its reference is cleaned up properly
         resp = self.app.delete('/user/%s/' % user_3['id'])
@@ -481,10 +509,10 @@ class MongoRestTestCase(unittest.TestCase):
         resp = self.app.get('/posts/%s/' % post['id'])
         response_success(resp)
 
-        self.assertEqual(json.loads(resp.data)['user_lists'], [])
+        self.assertEqual(resp_json(resp)['user_lists'], [])
 
         post['user_lists'] = []
-        compare_req_resp(post, json.loads(resp.data))
+        compare_req_resp(post, resp_json(resp))
 
     def test_dummy_auth(self):
         resp = self.app.get('/auth/')
@@ -500,103 +528,103 @@ class MongoRestTestCase(unittest.TestCase):
 
         resp = self.app.get('/posts/?_limit=10')
         response_success(resp)
-        data = json.loads(resp.data)
+        data = resp_json(resp)
         self.assertEqual(len(data['data']), 10)
         self.assertEqual(data['has_more'], True)
 
         resp = self.app.get('/posts/?_skip=100')
         response_success(resp)
-        data = json.loads(resp.data)
+        data = resp_json(resp)
         self.assertEqual(len(data['data']), 1)
         self.assertEqual(data['has_more'], False)
 
         resp = self.app.get('/posts/?_limit=1')
         response_success(resp)
-        data = json.loads(resp.data)
+        data = resp_json(resp)
         self.assertEqual(len(data['data']), 1)
         self.assertEqual(data['has_more'], True)
 
         resp = self.app.get('/posts/?_limit=0')
         response_success(resp)
-        data = json.loads(resp.data)
+        data = resp_json(resp)
         self.assertEqual(len(data['data']), 0)
         self.assertEqual(data['has_more'], True)
 
         resp = self.app.get('/posts/?_skip=100&_limit=1')
         response_success(resp)
-        data = json.loads(resp.data)
+        data = resp_json(resp)
         self.assertEqual(len(data['data']), 1)
         self.assertEqual(data['has_more'], False)
 
         # default limit
         resp = self.app.get('/posts/')
         response_success(resp)
-        data = json.loads(resp.data)
+        data = resp_json(resp)
         self.assertEqual(len(data['data']), 100)
 
         # _limit > max_limit
         resp = self.app.get('/posts/?_limit=101')
         response_error(resp, code=400)
-        data = json.loads(resp.data)
+        data = resp_json(resp)
         self.assertEqual(data['error'], 'The limit you set is larger than the maximum limit for this resource (max_limit = 100).')
 
         # respect custom max_limit
         resp = self.app.get('/posts10/?_limit=11')
         response_error(resp, code=400)
-        data = json.loads(resp.data)
+        data = resp_json(resp)
         self.assertEqual(data['error'], 'The limit you set is larger than the maximum limit for this resource (max_limit = 10).')
 
         resp = self.app.get('/posts10/')
         response_success(resp)
-        data = json.loads(resp.data)
+        data = resp_json(resp)
         self.assertEqual(len(data['data']), 10)
 
         resp = self.app.get('/posts10/?_limit=5')
         response_success(resp)
-        data = json.loads(resp.data)
+        data = resp_json(resp)
         self.assertEqual(len(data['data']), 5)
 
         resp = self.app.get('/posts250/?_limit=251')
         response_error(resp, code=400)
-        data = json.loads(resp.data)
+        data = resp_json(resp)
         self.assertEqual(data['error'], 'The limit you set is larger than the maximum limit for this resource (max_limit = 250).')
 
         resp = self.app.get('/posts250/')
         response_success(resp)
-        data = json.loads(resp.data)
+        data = resp_json(resp)
         self.assertEqual(len(data['data']), 100)
 
         resp = self.app.get('/posts250/?_limit=10')
         response_success(resp)
-        data = json.loads(resp.data)
+        data = resp_json(resp)
         self.assertEqual(len(data['data']), 10)
 
     def test_garbage_args(self):
         resp = self.app.get('/posts/?_limit=garbage')
         response_error(resp, code=400)
-        self.assertEqual(json.loads(resp.data)['error'],
+        self.assertEqual(resp_json(resp)['error'],
                          '_limit must be an integer (got "garbage" instead).')
 
         resp = self.app.get('/posts/?_skip=garbage')
         response_error(resp, code=400)
-        self.assertEqual(json.loads(resp.data)['error'],
+        self.assertEqual(resp_json(resp)['error'],
                          '_skip must be an integer (got "garbage" instead).')
 
         resp = self.app.get('/posts/?_skip=-1')
         response_error(resp, code=400)
-        self.assertEqual(json.loads(resp.data)['error'],
+        self.assertEqual(resp_json(resp)['error'],
                          '_skip must be a non-negative integer (got "-1" instead).')
 
     def test_fields(self):
         resp = self.app.get('/user/%s/?_fields=email' % self.user_1_obj['id'])
         response_success(resp)
-        user = json.loads(resp.data)
-        self.assertEqual(user.keys(), ['email'])
+        user = resp_json(resp)
+        self.assertEqual(set(user), set(['email']))
 
         resp = self.app.get('/user/%s/?_fields=first_name,last_name' % self.user_1_obj['id'])
         response_success(resp)
-        user = json.loads(resp.data)
-        self.assertEqual(set(user.keys()), set(['first_name', 'last_name']))
+        user = resp_json(resp)
+        self.assertEqual(set(user), set(['first_name', 'last_name']))
 
         # Make sure all fields can still be posted.
         test_user_data = {
@@ -608,45 +636,48 @@ class MongoRestTestCase(unittest.TestCase):
 
         resp = self.app.post('/user/?_fields=id', data=json.dumps(test_user_data))
         response_success(resp)
-        user = json.loads(resp.data)
-        self.assertEqual(user.keys(), ['id'])
+        user = resp_json(resp)
+        self.assertEqual(set(user), set(['id']))
 
     def test_invalid_json(self):
         resp = self.app.post('/user/', data='{\"}')
         response_error(resp, code=400)
-        resp = json.loads(resp.data)
+        resp = resp_json(resp)
         self.assertEqual(resp['error'], 'The request contains invalid JSON.')
 
     def test_chunked_request(self):
         resp = self.app.post('/a/', data=json.dumps({ 'txt': 'test' }), headers={'Transfer-Encoding': 'chunked'})
         response_error(resp, code=400)
-        self.assertEqual(json.loads(resp.data), { 'error': 'Chunked Transfer-Encoding is not supported.' })
+        self.assertEqual(resp_json(resp), { 'error': 'Chunked Transfer-Encoding is not supported.' })
 
+    # Original MongoEngine does not support assigning a string ID to a dbref
+    # reference -- we'd have to use a schema.
+    @unittest.skipIf(not SafeReferenceField, "SafeReferenceField not available")
     def test_dbref_vs_objectid(self):
         resp = self.app.post('/a/', data=json.dumps({ "txt": "some text 1" }))
         response_success(resp)
-        a1 = json.loads(resp.data)
+        a1 = resp_json(resp)
 
         resp = self.app.post('/a/', data=json.dumps({ "txt": "some text 2" }))
         response_success(resp)
-        a2 = json.loads(resp.data)
+        a2 = resp_json(resp)
 
         resp = self.app.post('/b/', data=json.dumps({ "ref": a1['id'], "txt": "text" }))
         response_success(resp)
-        dbref_obj = json.loads(resp.data)
+        dbref_obj = resp_json(resp)
 
         resp = self.app.post('/c/', data=json.dumps({ "ref": a1['id'], "txt": "text" }))
         response_success(resp)
-        objectid_obj = json.loads(resp.data)
+        objectid_obj = resp_json(resp)
 
         # compare objects with a dbref reference and an objectid reference
         resp = self.app.get('/b/{0}/'.format(dbref_obj['id']))
         response_success(resp)
-        dbref_obj = json.loads(resp.data)
+        dbref_obj = resp_json(resp)
 
         resp = self.app.get('/c/{0}/'.format(objectid_obj['id']))
         response_success(resp)
-        objectid_obj = json.loads(resp.data)
+        objectid_obj = resp_json(resp)
 
         self.assertEqual(dbref_obj['ref'], objectid_obj['ref'])
         self.assertEqual(dbref_obj['txt'], objectid_obj['txt'])
@@ -660,11 +691,11 @@ class MongoRestTestCase(unittest.TestCase):
 
         resp = self.app.get('/b/{0}/'.format(dbref_obj['id']))
         response_success(resp)
-        dbref_obj = json.loads(resp.data)
+        dbref_obj = resp_json(resp)
 
         resp = self.app.get('/c/{0}/'.format(objectid_obj['id']))
         response_success(resp)
-        objectid_obj = json.loads(resp.data)
+        objectid_obj = resp_json(resp)
 
         self.assertEqual(dbref_obj['ref'], a2['id'])
         self.assertEqual(dbref_obj['ref'], objectid_obj['ref'])
@@ -675,35 +706,35 @@ class MongoRestTestCase(unittest.TestCase):
 
         resp = self.app.get('/test_view_method/%s/' % doc.pk)
         response_success(resp)
-        self.assertEqual(json.loads(resp.data), {'method': 'Fetch'})
+        self.assertEqual(resp_json(resp), {'method': 'Fetch'})
 
         resp = self.app.get('/test_view_method/')
         response_success(resp)
-        self.assertEqual(json.loads(resp.data), {'method': 'List'})
+        self.assertEqual(resp_json(resp), {'method': 'List'})
 
         resp = self.app.post('/test_view_method/', data=json.dumps({
             'txt': 'doc2'
         }))
         response_success(resp)
-        self.assertEqual(json.loads(resp.data), {'method': 'Create'})
+        self.assertEqual(resp_json(resp), {'method': 'Create'})
 
         resp = self.app.put('/test_view_method/%s/' % doc.pk, data=json.dumps({
             'txt': 'doc1new'
         }))
         response_success(resp)
-        self.assertEqual(json.loads(resp.data), {'method': 'Update'})
+        self.assertEqual(resp_json(resp), {'method': 'Update'})
 
         resp = self.app.put('/test_view_method/', data=json.dumps({
             'txt': 'doc'
         }))
         response_success(resp)
-        self.assertEqual(json.loads(resp.data), {'method': 'BulkUpdate'})
+        self.assertEqual(resp_json(resp), {'method': 'BulkUpdate'})
 
         resp = self.app.delete('/test_view_method/%s/' % doc.pk, data=json.dumps({
             'txt': 'doc'
         }))
         response_success(resp)
-        self.assertEqual(json.loads(resp.data), {'method': 'Delete'})
+        self.assertEqual(resp_json(resp), {'method': 'Delete'})
 
     def test_methods_success(self):
         doc1 = example.MethodTestDoc.objects.create(txt='doc1')
@@ -935,7 +966,7 @@ class MongoRestTestCase(unittest.TestCase):
         """Make sure we gracefully handle requests where an invalid Accept header is sent."""
         resp = self.app.get('/user/%s/' % self.user_1_obj['id'], headers={ 'Accept': 'whatever' })
         response_error(resp)
-        self.assertEqual(resp.data, 'Invalid Accept header requested')
+        self.assertEqual(resp.data, b'Invalid Accept header requested')
 
     def test_bulk_update_limit(self):
         """
@@ -956,7 +987,7 @@ class MongoRestTestCase(unittest.TestCase):
             'title': 'Title'
         }))
         response_error(resp, code=400)
-        self.assertEqual(json.loads(resp.data), {
+        self.assertEqual(resp_json(resp), {
             'errors': [
                 "It's not allowed to update more than 10 objects at once"
             ]
@@ -983,7 +1014,7 @@ class MongoRestSchemaTestCase(unittest.TestCase):
             ]
         }))
         response_success(resp)
-        person = json.loads(resp.data)
+        person = resp_json(resp)
 
         person_id = person['id']
 
@@ -1004,7 +1035,7 @@ class MongoRestSchemaTestCase(unittest.TestCase):
             ]
         }))
         response_success(resp)
-        person = json.loads(resp.data)
+        person = resp_json(resp)
         self.assertEqual(len(person['languages']), 2)
         self.assertEqual(person['name'], 'John')
         self.assertEqual(person['languages'][0]['id'], english_id)
@@ -1021,7 +1052,7 @@ class MongoRestSchemaTestCase(unittest.TestCase):
             ]
         }))
         response_success(resp)
-        person = json.loads(resp.data)
+        person = resp_json(resp)
         self.assertEqual(len(person['languages']), 2)
         self.assertEqual(person['name'], 'John')
         self.assertEqual(person['languages'][0]['id'], english_id)
@@ -1032,7 +1063,7 @@ class MongoRestSchemaTestCase(unittest.TestCase):
         # Also no change (empty data)
         resp = self.app.put('/person/%s/' % person_id, data=json.dumps({ }))
         response_success(resp)
-        person = json.loads(resp.data)
+        person = resp_json(resp)
         self.assertEqual(len(person['languages']), 2)
         self.assertEqual(person['name'], 'John')
         self.assertEqual(person['languages'][0]['id'], english_id)
@@ -1048,7 +1079,7 @@ class MongoRestSchemaTestCase(unittest.TestCase):
             ]
         }))
         response_success(resp)
-        person = json.loads(resp.data)
+        person = resp_json(resp)
         self.assertEqual(len(person['languages']), 2)
         self.assertEqual(person['name'], 'John')
         self.assertEqual(person['languages'][0]['id'], english_id)
@@ -1065,7 +1096,7 @@ class MongoRestSchemaTestCase(unittest.TestCase):
             ]
         }))
         response_success(resp)
-        person = json.loads(resp.data)
+        person = resp_json(resp)
         self.assertEqual(len(person['languages']), 3)
         self.assertEqual(person['name'], 'John')
         self.assertEqual(person['languages'][0]['id'], english_id)
@@ -1081,7 +1112,7 @@ class MongoRestSchemaTestCase(unittest.TestCase):
             ]
         }))
         response_success(resp)
-        person = json.loads(resp.data)
+        person = resp_json(resp)
         self.assertEqual(len(person['languages']), 1)
         self.assertEqual(person['name'], 'John')
         self.assertEqual(person['languages'][0]['id'], german_id)
@@ -1095,7 +1126,7 @@ class MongoRestSchemaTestCase(unittest.TestCase):
             ]
         }))
         response_success(resp)
-        person = json.loads(resp.data)
+        person = resp_json(resp)
         self.assertEqual(len(person['languages']), 2)
         self.assertEqual(person['name'], 'John')
         self.assertEqual(person['languages'][0]['id'], german_id)
@@ -1116,16 +1147,16 @@ class MongoRestSchemaTestCase(unittest.TestCase):
             'datetime': '2010-01-01T00:00:00',
         }))
         response_success(resp)
-        datetime = json.loads(resp.data)
-        self.assertEqual(datetime['datetime'], '2010-01-01T00:00:00+00:00')
+        datetime = resp_json(resp)
+        self.assertEqual(datetime['datetime'], '2010-01-01T00:00:00')
 
         with query_counter() as c:
             resp = self.app.put('/datetime/%s/' % datetime['id'], data=json.dumps({
                 'datetime': '2010-01-02T00:00:00',
             }))
             response_success(resp)
-            datetime = json.loads(resp.data)
-            self.assertEqual(datetime['datetime'], '2010-01-02T00:00:00+00:00')
+            datetime = resp_json(resp)
+            self.assertEqual(datetime['datetime'], '2010-01-02T00:00:00')
 
             self.assertEqual(c, 3) # query, update, query (reload)
 
@@ -1134,8 +1165,8 @@ class MongoRestSchemaTestCase(unittest.TestCase):
                 'datetime': '2010-01-02T00:00:00',
             }))
             response_success(resp)
-            datetime = json.loads(resp.data)
-            self.assertEqual(datetime['datetime'], '2010-01-02T00:00:00+00:00')
+            datetime = resp_json(resp)
+            self.assertEqual(datetime['datetime'], '2010-01-02T00:00:00')
 
             # Ideally this would be one query since we're not modifying, but
             # in the generic case the save method may have other side effects
@@ -1148,8 +1179,8 @@ class MongoRestSchemaTestCase(unittest.TestCase):
             resp = self.app.put('/datetime/%s/' % datetime['id'], data=json.dumps({
             }))
             response_success(resp)
-            datetime = json.loads(resp.data)
-            self.assertEqual(datetime['datetime'], '2010-01-02T00:00:00+00:00')
+            datetime = resp_json(resp)
+            self.assertEqual(datetime['datetime'], '2010-01-02T00:00:00')
 
             self.assertEqual(c, 2) # 2x query (with reload)
 
@@ -1168,14 +1199,14 @@ class MongoRestSchemaTestCase(unittest.TestCase):
             }
         }))
         response_error(resp, code=400)
-        self.assertEqual(json.loads(resp.data), { 'error': 'The request contains invalid JSON.' })
+        self.assertEqual(resp_json(resp), { 'error': 'The request contains invalid JSON.' })
 
         # test update
         resp = self.app.post('/dict_doc/', data=json.dumps({
             'dict': { 'aaa': 'bbb' }
         }))
         response_success(resp)
-        resp = self.app.put('/dict_doc/%s/' % json.loads(resp.data)['id'], data=json.dumps({
+        resp = self.app.put('/dict_doc/%s/' % resp_json(resp)['id'], data=json.dumps({
             'dict': {
                 'nan': float('NaN'),
                 'inf': float('inf'),
@@ -1183,7 +1214,7 @@ class MongoRestSchemaTestCase(unittest.TestCase):
             }
         }))
         response_error(resp, code=400)
-        self.assertEqual(json.loads(resp.data), { 'error': 'The request contains invalid JSON.' })
+        self.assertEqual(resp_json(resp), { 'error': 'The request contains invalid JSON.' })
 
     def test_send_bad_json(self):
         """

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
-envlist = py27
+envlist = py27,py35
 
 [testenv]
 commands=nosetests
 deps=
     nose
-    -rrequirements.txt
+    py27: -rrequirements.txt
+    py35: -rrequirements3.txt


### PR DESCRIPTION
This is tested on:
- Python 2.7 and our own MongoEngine fork
- Python 3.5 and upstream MongoEngine

Note that I skipped two tests since upstream MongoEngine doesn't have certain features like `SafeReferenceField`.