### PR TITLE
Extensible resource field serialization

### DIFF
--- a/flask_mongorest/utils.py
+++ b/flask_mongorest/utils.py
@@ -28,6 +28,7 @@ class MongoEncoder(json.JSONEncoder):
             return str(value)
         return super(MongoEncoder, self).default(value, **kwargs)
 
+
 try:
     cmp
 except NameError: # Python 3

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1321,6 +1321,7 @@ class InternalTestCase(unittest.TestCase):
             }
         })
 
+
 if __name__ == '__main__':
     unittest.main()
 


### PR DESCRIPTION
Split `Resource.serialize` into separate field-type serialization methods. This makes it easier to add serialization for new field types.