### PR TITLE
Package requirements are broken in PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,12 +28,14 @@ setup(
     zip_safe=False,
     platforms='any',
     setup_requires=[
+        'nose',
+    ],
+    install_requires=[
         'Flask-Views',
         'Flask-MongoEngine',
         'mimerender',
-        'nose',
         'python-dateutil',
-        'cleancat'
+        'cleancat',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Package requirements aren't recognized when installing from PyPI.
Also, it could be helpful to move `nose` to something like

```python
    extras_require={
        'test': ['nose'],
    },
```
After that, it will be possible to setup test environment like that
```
python setup.py develop
pip install Flask-MongoRest[test]
```