### PR TITLE
`params` doesn't make sense if we don't have a request

### DIFF
--- a/flask_mongorest/resources.py
+++ b/flask_mongorest/resources.py
@@ -161,6 +161,10 @@ class Resource(object):
     @property
     def raw_data(self):
         """Validate and return parsed JSON payload."""
+        if not has_request_context():
+            # `raw_data` doesn't make sense if we don't have a request
+            raise AttributeError
+
         if not hasattr(self, '_raw_data'):
             if request.method in ('PUT', 'POST') or request.data:
                 if request.mimetype and 'json' not in request.mimetype:

--- a/flask_mongorest/resources.py
+++ b/flask_mongorest/resources.py
@@ -3,7 +3,7 @@ import mongoengine
 
 from bson.dbref import DBRef
 from bson.objectid import ObjectId
-from flask import request, url_for
+from flask import has_request_context, request, url_for
 try:
     from urllib.parse import urlparse
 except ImportError: # Python 2
@@ -131,6 +131,10 @@ class Resource(object):
         2. As a _params property in the JSON payload. For example:
              { '_params': { 'status': 'active', '_limit': '10' } }
         """
+        if not has_request_context():
+            # `params` doesn't make sense if we don't have a request
+            raise AttributeError
+
         if not hasattr(self, '_params'):
             if '_params' in self.raw_data:
                 self._params = self.raw_data['_params']


### PR DESCRIPTION
If we don't have an active request context, evaluating `params` doesn't make sense and is analogous to the attribute not existing at all, so we raise an `AttributeError` to make `hasattr` return `False`.