### PR TITLE
docs: Fix simple typo, respresentation -> representation

### DIFF
--- a/flask_mongorest/resources.py
+++ b/flask_mongorest/resources.py
@@ -447,7 +447,7 @@ class Resource(object):
     def serialize(self, obj, **kwargs):
         """
         Given an object, serialize it, turning it into its JSON
-        respresentation.
+        representation.
         """
         if not obj:
             return {}


### PR DESCRIPTION
There is a small typo in flask_mongorest/resources.py.

Should read `representation` rather than `respresentation`.

