### PR TITLE
Fix empty "xx__in=" filters

### DIFF
--- a/flask_mongorest/operators.py
+++ b/flask_mongorest/operators.py
@@ -108,6 +108,10 @@ class In(Operator):
     op = 'in'
 
     def prepare_queryset_kwargs(self, field, value, negate):
+        # this is null if the user submits an empty in expression (like
+        # "user__in=")
+        value = value or []
+
         # only use 'in' or 'nin' if multiple values are specified
         if ',' in value:
             value = value.split(',')

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -426,6 +426,11 @@ class MongoRestTestCase(unittest.TestCase):
         posts = resp_json(resp)
         self.assertEqual(len(posts['data']), 2)
 
+        resp = self.app.get('/posts/?title__in=')
+        response_success(resp)
+        posts = resp_json(resp)
+        self.assertEqual(len(posts['data']), 0)
+
         resp = self.app.get('/user/?datetime=%s' % '2012-10-09 10:00:00')
         response_success(resp)
         users = resp_json(resp)


### PR DESCRIPTION
This change defaults the value to an empty list, which should return no results. It also won't error anymore.

Previously, for empty `xx__in=` filters, `value` would be `None` and so the `',' in value` check would throw a `TypeError`.

I'm not sure why CI isn't working, but I've run tests locally to confirm that it passes.