### PR TITLE
Support delayed app initialization

### DIFF
--- a/flask_mongorest/__init__.py
+++ b/flask_mongorest/__init__.py
@@ -1,85 +1,10 @@
-from flask import Blueprint
+from .methods import BulkUpdate, Create, List
+from .mongorest import MongoRest
 
-from flask_mongorest.methods import BulkUpdate, Create, List
-
-
-class DelayedApp:
-    """
-    Stores URL rules for later merging with an application URL map.
-    """
-
-    def __init__(self):
-        self.url_rules = []
-
-    def add_url_rule(self, *args, **kwargs):
-        self.url_rules.append((args, kwargs))
-
-
-def register_class(app: DelayedApp, klass, *, url_prefix, **kwargs):
-    # Construct a url based on a 'name' kwarg with a fallback to the
-    # view's class name. Note that the name must be unique.
-    name = kwargs.pop("name", klass.__name__)
-    url = kwargs.pop("url", None)
-    if not url:
-        document_name = klass.resource.document.__name__.lower()
-        url = f"/{document_name}/"
-
-    # Insert the url prefix, if it exists
-    if url_prefix:
-        url = f"{url_prefix}{url}"
-
-    # Add url rules
-    pk_type = kwargs.pop("pk_type", "string")
-    view_func = klass.as_view(name)
-    if List in klass.methods:
-        app.add_url_rule(
-            url,
-            defaults={"pk": None},
-            view_func=view_func,
-            methods=[List.method],
-            **kwargs,
-        )
-    if Create in klass.methods or BulkUpdate in klass.methods:
-        app.add_url_rule(
-            url,
-            view_func=view_func,
-            methods=[x.method for x in klass.methods if x in (Create, BulkUpdate)],
-            **kwargs,
-        )
-    app.add_url_rule(
-        f"{url}<{pk_type}:pk>/",
-        view_func=view_func,
-        methods=[x.method for x in klass.methods if x not in (List, BulkUpdate)],
-        **kwargs,
-    )
-
-
-class MongoRest:
-    def __init__(self, app=None, url_prefix="", template_folder=""):
-        self.url_prefix = url_prefix
-        self.template_folder = template_folder
-        self._app = DelayedApp()
-
-        if app is not None:
-            self.init_app(app)
-
-    def init_app(self, app):
-        """
-        Provides delayed application instance initialization to support
-        Flask application factory pattern. For further details on application
-        factories see: https://flask.palletsprojects.com/en/2.0.x/extensiondev/
-        """
-
-        app.register_blueprint(
-            Blueprint(self.url_prefix, __name__, template_folder=self.template_folder)
-        )
-
-        for args, kwargs in self._app.url_rules:
-            app.add_url_rule(*args, **kwargs)
-
-    def register(self, **kwargs):
-        def decorator(klass):
-            register_class(self._app, klass, url_prefix=self.url_prefix, **kwargs)
-            return klass
-
-        return decorator
+__all__ = [
+    "MongoRest",
+    # TODO these methods probably shouldn't be exposed here?
+    "BulkUpdate",
+    "Create",
+    "List",
+]

--- a/flask_mongorest/__init__.py
+++ b/flask_mongorest/__init__.py
@@ -3,6 +3,45 @@ from flask import Blueprint
 from flask_mongorest.methods import BulkUpdate, Create, List
 
 
+def register_class(app, klass, *, url_prefix, **kwargs):
+    # Construct a url based on a 'name' kwarg with a fallback to the
+    # view's class name. Note that the name must be unique.
+    name = kwargs.pop("name", klass.__name__)
+    url = kwargs.pop("url", None)
+    if not url:
+        document_name = klass.resource.document.__name__.lower()
+        url = f"/{document_name}/"
+
+    # Insert the url prefix, if it exists
+    if url_prefix:
+        url = f"{url_prefix}{url}"
+
+    # Add url rules
+    pk_type = kwargs.pop("pk_type", "string")
+    view_func = klass.as_view(name)
+    if List in klass.methods:
+        app.add_url_rule(
+            url,
+            defaults={"pk": None},
+            view_func=view_func,
+            methods=[List.method],
+            **kwargs,
+        )
+    if Create in klass.methods or BulkUpdate in klass.methods:
+        app.add_url_rule(
+            url,
+            view_func=view_func,
+            methods=[x.method for x in klass.methods if x in (Create, BulkUpdate)],
+            **kwargs,
+        )
+    app.add_url_rule(
+        f"{url}<{pk_type}:pk>/",
+        view_func=view_func,
+        methods=[x.method for x in klass.methods if x not in (List, BulkUpdate)],
+        **kwargs,
+    )
+
+
 class MongoRest:
     def __init__(self, app, **kwargs):
         self.app = app
@@ -13,46 +52,7 @@ class MongoRest:
 
     def register(self, **kwargs):
         def decorator(klass):
-            # Construct a url based on a 'name' kwarg with a fallback to the
-            # view's class name. Note that the name must be unique.
-            name = kwargs.pop("name", klass.__name__)
-            url = kwargs.pop("url", None)
-            if not url:
-                document_name = klass.resource.document.__name__.lower()
-                url = f"/{document_name}/"
-
-            # Insert the url prefix, if it exists
-            if self.url_prefix:
-                url = f"{self.url_prefix}{url}"
-
-            # Add url rules
-            pk_type = kwargs.pop("pk_type", "string")
-            view_func = klass.as_view(name)
-            if List in klass.methods:
-                self.app.add_url_rule(
-                    url,
-                    defaults={"pk": None},
-                    view_func=view_func,
-                    methods=[List.method],
-                    **kwargs,
-                )
-            if Create in klass.methods or BulkUpdate in klass.methods:
-                self.app.add_url_rule(
-                    url,
-                    view_func=view_func,
-                    methods=[
-                        x.method for x in klass.methods if x in (Create, BulkUpdate)
-                    ],
-                    **kwargs,
-                )
-            self.app.add_url_rule(
-                f"{url}<{pk_type}:pk>/",
-                view_func=view_func,
-                methods=[
-                    x.method for x in klass.methods if x not in (List, BulkUpdate)
-                ],
-                **kwargs,
-            )
+            register_class(self.app, klass, url_prefix=self.url_prefix, **kwargs)
             return klass
 
         return decorator

--- a/flask_mongorest/mongorest.py
+++ b/flask_mongorest/mongorest.py
@@ -1,0 +1,85 @@
+from flask import Blueprint
+
+from flask_mongorest import List, Create, BulkUpdate
+
+
+class DelayedApp:
+    """
+    Stores URL rules for later merging with an application URL map.
+    """
+
+    def __init__(self):
+        self.url_rules = []
+
+    def add_url_rule(self, *args, **kwargs):
+        self.url_rules.append((args, kwargs))
+
+
+def register_class(app: DelayedApp, klass, *, url_prefix, **kwargs):
+    # Construct a url based on a 'name' kwarg with a fallback to the
+    # view's class name. Note that the name must be unique.
+    name = kwargs.pop("name", klass.__name__)
+    url = kwargs.pop("url", None)
+    if not url:
+        document_name = klass.resource.document.__name__.lower()
+        url = f"/{document_name}/"
+
+    # Insert the url prefix, if it exists
+    if url_prefix:
+        url = f"{url_prefix}{url}"
+
+    # Add url rules
+    pk_type = kwargs.pop("pk_type", "string")
+    view_func = klass.as_view(name)
+    if List in klass.methods:
+        app.add_url_rule(
+            url,
+            defaults={"pk": None},
+            view_func=view_func,
+            methods=[List.method],
+            **kwargs,
+        )
+    if Create in klass.methods or BulkUpdate in klass.methods:
+        app.add_url_rule(
+            url,
+            view_func=view_func,
+            methods=[x.method for x in klass.methods if x in (Create, BulkUpdate)],
+            **kwargs,
+        )
+    app.add_url_rule(
+        f"{url}<{pk_type}:pk>/",
+        view_func=view_func,
+        methods=[x.method for x in klass.methods if x not in (List, BulkUpdate)],
+        **kwargs,
+    )
+
+
+class MongoRest:
+    def __init__(self, app=None, url_prefix="", template_folder=""):
+        self.url_prefix = url_prefix
+        self.template_folder = template_folder
+        self._app = DelayedApp()
+
+        if app is not None:
+            self.init_app(app)
+
+    def init_app(self, app):
+        """
+        Provides delayed application instance initialization to support
+        Flask application factory pattern. For further details on application
+        factories see: https://flask.palletsprojects.com/en/2.0.x/extensiondev/
+        """
+
+        app.register_blueprint(
+            Blueprint(self.url_prefix, __name__, template_folder=self.template_folder)
+        )
+
+        for args, kwargs in self._app.url_rules:
+            app.add_url_rule(*args, **kwargs)
+
+    def register(self, **kwargs):
+        def decorator(klass):
+            register_class(self._app, klass, url_prefix=self.url_prefix, **kwargs)
+            return klass
+
+        return decorator

--- a/flask_mongorest/mongorest.py
+++ b/flask_mongorest/mongorest.py
@@ -1,11 +1,11 @@
 from flask import Blueprint
 
-from flask_mongorest import List, Create, BulkUpdate
+from flask_mongorest import BulkUpdate, Create, List
 
 
 class DelayedApp:
     """
-    Stores URL rules for later merging with an application URL map.
+    Store URL rules for later merging with an application URL map.
     """
 
     def __init__(self):
@@ -65,11 +65,10 @@ class MongoRest:
 
     def init_app(self, app):
         """
-        Provides delayed application instance initialization to support
+        Provide delayed application instance initialization to support
         Flask application factory pattern. For further details on application
         factories see: https://flask.palletsprojects.com/en/2.0.x/extensiondev/
         """
-
         app.register_blueprint(
             Blueprint(self.url_prefix, __name__, template_folder=self.template_folder)
         )

--- a/flask_mongorest/mongorest.py
+++ b/flask_mongorest/mongorest.py
@@ -55,7 +55,7 @@ def register_class(app: DelayedApp, klass, *, url_prefix, **kwargs):
 
 
 class MongoRest:
-    def __init__(self, app=None, url_prefix="", template_folder=""):
+    def __init__(self, app=None, url_prefix="", template_folder="templates"):
         self.url_prefix = url_prefix
         self.template_folder = template_folder
         self._app = DelayedApp()


### PR DESCRIPTION
Closes https://github.com/closeio/flask-mongorest/issues/81

* Split register_class logic out of `MongoRest` class
* Move app initialization to `MongoRest().init_app(app)`
* Move `MongoRest` and company out of `__init__.py` and into `mongorest.py`

There's a workaround required here to support the decorator registration pattern exposed. Not all views are guaranteed to be imported/registered at the time `init_app(app)` is called. If `MongoRest` does not keep a running list of app objects it needs to register views to, none of those will actually be registered. So, this implements a delayed app class that just collects args/kwargs, then also collects a list of references to apps. Views are batch registered during `init_app`, then also registered to previously-initialized apps within `MongoRest.register`.