### PR TITLE
docs: Fix a few typos

### DIFF
--- a/flask_mongorest/operators.py
+++ b/flask_mongorest/operators.py
@@ -102,7 +102,7 @@ class Exact(Operator):
 
     def prepare_queryset_kwargs(self, field, value, negate):
         # Using <field>__exact causes mongoengine to generate a regular
-        # expresison query, which we'd like to avoid.
+        # expression query, which we'd like to avoid.
         if negate:
             return {f"{field}__ne": value}
         else:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1336,7 +1336,7 @@ class MongoRestSchemaTestCase(unittest.TestCase):
 
     def test_send_bad_json(self):
         """
-        Make sure that - even if we store invalid JSON in databse, we error out
+        Make sure that - even if we store invalid JSON in database, we error out
         instead of sending invalid data to the user.
         """
         doc = example.DictDoc.objects.create(


### PR DESCRIPTION
There are small typos in:
- flask_mongorest/operators.py
- tests/__init__.py

Fixes:
- Should read `expression` rather than `expresison`.
- Should read `database` rather than `databse`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md